### PR TITLE
Fixed installation on Arch Linux

### DIFF
--- a/pasarguard.sh
+++ b/pasarguard.sh
@@ -57,7 +57,7 @@ detect_os() {
     elif [ -f /etc/redhat-release ]; then
         OS=$(cat /etc/redhat-release | awk '{print $1}')
     elif [ -f /etc/arch-release ]; then
-        OS="Arch"
+        OS="Arch Linux"
     else
         colorized_echo red "Unsupported operating system"
         exit 1


### PR DESCRIPTION
Fixed installation on Arch Linux. Since the name in Arch's is "Arch Linux", not "Arch", the script didn't work.                  

