### PR TITLE
feat(installer): add full SSL setup flow (domain/ip/custom), no-ssl mode, and ACME auto-renew

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,14 @@
 | `--version <vX.Y.Z>` | Install a specific version, including pre-releases (e.g., `v0.5.2`, `v1.0.0-beta.1`)       |
 | `--dev`              | Install the latest development version (only for versions **before v1.0.0**)               |
 | `--pre-release`      | Install the latest pre-release version (only for versions **v1.0.0 and later**)            |
+| `--ssl`              | Enable SSL setup prompt during install (Domain/IP/Custom certificate).                      |
 | `--no-ssl`           | Skip SSL setup during install (dashboard will bind to localhost only).                      |
-| `--ssl-domain`       | Issue SSL cert non-interactively for a domain (example: `--ssl-domain panel.example.com`). |
+| `--ssl-domain`       | Issue SSL cert directly for domain mode (example: `--ssl-domain panel.example.com`).        |
 | `--ssl-http-port`    | ACME HTTP challenge port for SSL issuance (default: `80`).                                   |
 
 > ℹ️ `postgres` and `timescaledb` are only supported in versions **v1.0.0 and later**.  
 > ℹ️ Pre-release versions (e.g., `v1.0.0-beta.1`) can also be installed using `--version`.
+> ℹ️ During install, SSL menu supports: Let's Encrypt Domain, Let's Encrypt IP (short-lived), Custom cert/key path, or No SSL.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
 | `--version <vX.Y.Z>` | Install a specific version, including pre-releases (e.g., `v0.5.2`, `v1.0.0-beta.1`)       |
 | `--dev`              | Install the latest development version (only for versions **before v1.0.0**)               |
 | `--pre-release`      | Install the latest pre-release version (only for versions **v1.0.0 and later**)            |
+| `--no-ssl`           | Skip SSL setup during install (dashboard will bind to localhost only).                      |
+| `--ssl-domain`       | Issue SSL cert non-interactively for a domain (example: `--ssl-domain panel.example.com`). |
+| `--ssl-http-port`    | ACME HTTP challenge port for SSL issuance (default: `80`).                                   |
 
 > ℹ️ `postgres` and `timescaledb` are only supported in versions **v1.0.0 and later**.  
 > ℹ️ Pre-release versions (e.g., `v1.0.0-beta.1`) can also be installed using `--version`.

--- a/pasarguard.sh
+++ b/pasarguard.sh
@@ -39,6 +39,71 @@ replace_or_append_env_var() {
     fi
 }
 
+set_or_uncomment_env_var() {
+    local key="$1"
+    local value="$2"
+    local quote_value="${3:-false}"
+    local target_file="${4:-$ENV_FILE}"
+    local formatted_value="$value"
+    local tmp_file=""
+
+    if [ "$quote_value" = "true" ]; then
+        local sanitized_value="${value//\"/\\\"}"
+        formatted_value="\"$sanitized_value\""
+    fi
+
+    [ -f "$target_file" ] || touch "$target_file"
+    tmp_file=$(mktemp)
+
+    awk -v env_key="$key" -v env_line="${key} = ${formatted_value}" '
+        BEGIN { replaced = 0 }
+        {
+            if ($0 ~ "^[[:space:]]*#?[[:space:]]*" env_key "[[:space:]]*=") {
+                if (replaced == 0) {
+                    print env_line
+                    replaced = 1
+                }
+                next
+            }
+            print
+        }
+        END {
+            if (replaced == 0) {
+                print env_line
+            }
+        }
+    ' "$target_file" >"$tmp_file"
+
+    mv "$tmp_file" "$target_file"
+}
+
+comment_out_env_var() {
+    local key="$1"
+    local target_file="${2:-$ENV_FILE}"
+    local tmp_file=""
+
+    [ -f "$target_file" ] || return 0
+    tmp_file=$(mktemp)
+
+    awk -v env_key="$key" '
+        BEGIN { done = 0 }
+        {
+            if ($0 ~ "^[[:space:]]*#?[[:space:]]*" env_key "[[:space:]]*=") {
+                if (done == 0) {
+                    line = $0
+                    sub("^[[:space:]]*#?[[:space:]]*" env_key "[[:space:]]*=[[:space:]]*", "", line)
+                    print "# " env_key " = " line
+                    done = 1
+                }
+                next
+            }
+            print
+        }
+    ' "$target_file" >"$tmp_file"
+
+    mv "$tmp_file" "$target_file"
+}
+
 delete_env_var() {
     local key="$1"
     local target_file="${2:-$ENV_FILE}"
@@ -290,6 +355,14 @@ get_acme_sh_binary() {
     return 1
 }
 
+ensure_acme_auto_renew() {
+    local acme_bin="$1"
+
+    [ -n "$acme_bin" ] || return 0
+    "$acme_bin" --upgrade --auto-upgrade >/dev/null 2>&1 || true
+    "$acme_bin" --install-cronjob >/dev/null 2>&1 || true
+}
+
 build_pasarguard_ssl_reload_command() {
     local backend_service=""
     backend_service=$(detect_pasarguard_backend_service 2>/dev/null || true)
@@ -356,7 +429,7 @@ setup_ssl_certificate() {
         return 1
     fi
 
-    "$acme_bin" --upgrade --auto-upgrade >/dev/null 2>&1 || true
+    ensure_acme_auto_renew "$acme_bin"
     chmod 600 "${cert_dir}/privkey.pem" 2>/dev/null || true
     chmod 644 "${cert_dir}/fullchain.pem" 2>/dev/null || true
 
@@ -439,7 +512,7 @@ setup_ip_ssl_certificate() {
         return 1
     fi
 
-    "$acme_bin" --upgrade --auto-upgrade >/dev/null 2>&1 || true
+    ensure_acme_auto_renew "$acme_bin"
     chmod 600 "${cert_dir}/privkey.pem" 2>/dev/null || true
     chmod 644 "${cert_dir}/fullchain.pem" 2>/dev/null || true
 
@@ -482,16 +555,15 @@ enable_pasarguard_ssl_env() {
     local key_file="$2"
     local ca_type="${3:-public}"
 
-    disable_pasarguard_ssl_env
-    replace_or_append_env_var "UVICORN_SSL_CERTFILE" "$cert_file" true "$ENV_FILE"
-    replace_or_append_env_var "UVICORN_SSL_KEYFILE" "$key_file" true "$ENV_FILE"
-    replace_or_append_env_var "UVICORN_SSL_CA_TYPE" "$ca_type" true "$ENV_FILE"
+    set_or_uncomment_env_var "UVICORN_SSL_CERTFILE" "$cert_file" true "$ENV_FILE"
+    set_or_uncomment_env_var "UVICORN_SSL_KEYFILE" "$key_file" true "$ENV_FILE"
+    set_or_uncomment_env_var "UVICORN_SSL_CA_TYPE" "$ca_type" true "$ENV_FILE"
 }
 
 disable_pasarguard_ssl_env() {
-    delete_env_var "UVICORN_SSL_CERTFILE" "$ENV_FILE"
-    delete_env_var "UVICORN_SSL_KEYFILE" "$ENV_FILE"
-    delete_env_var "UVICORN_SSL_CA_TYPE" "$ENV_FILE"
+    comment_out_env_var "UVICORN_SSL_CERTFILE" "$ENV_FILE"
+    comment_out_env_var "UVICORN_SSL_KEYFILE" "$ENV_FILE"
+    comment_out_env_var "UVICORN_SSL_CA_TYPE" "$ENV_FILE"
 }
 
 setup_pasarguard_ssl_during_install() {


### PR DESCRIPTION
## Description
This PR improves `pasarguard.sh` install-time SSL handling and certificate lifecycle management.

### What changed
- Added full SSL setup choices during install:
  - Let's Encrypt Domain certificate
  - Let's Encrypt IP certificate (short-lived)
  - Custom certificate/key paths
  - No SSL
- Added/kept install flags for SSL control:
  - `--ssl`
  - `--no-ssl`
  - `--ssl-domain <domain>`
  - `--ssl-http-port <port>` (`--ssl-port` alias)
- Added ACME auto-renew hardening:
  - Runs `acme.sh --upgrade --auto-upgrade`
  - Ensures cron setup with `acme.sh --install-cronjob`
- Changed SSL env behavior to update existing `.env` keys in place (uncomment/edit) instead of appending new entries at file end:
  - `UVICORN_SSL_CERTFILE`
  - `UVICORN_SSL_KEYFILE`
  - `UVICORN_SSL_CA_TYPE`
- Reverted database driver behavior change:
  - Driver selection remains version-based as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added SSL/HTTPS support during installation with configurable options: `--ssl`, `--no-ssl`, `--ssl-domain`, and `--ssl-http-port`.
  * Support for domain-based, IP-based, and custom SSL certificates.
  * Automatic certificate issuance and renewal capabilities.

* **Documentation**
  * Updated README with SSL-related installation options and usage information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->