### PR TITLE
Fix node/panel image uninstall: avoid brittle parsing

### DIFF
--- a/pg-node.sh
+++ b/pg-node.sh
@@ -772,15 +772,30 @@ uninstall_node() {
     fi
 }
 uninstall_node_docker_images() {
-    images=$(docker images | grep node | awk '{print $3}')
-    if [ -n "$images" ]; then
-        colorized_echo yellow "Removing Docker images of node"
-        for image in $images; do
-            if docker rmi "$image" >/dev/null 2>&1; then
-                colorized_echo yellow "Image $image removed"
-            fi
-        done
+    local images
+    images=$(docker images --format '{{.Repository}} {{.ID}}' | awk '$1 ~ /^pasarguard\/node(:|$)/ {print $2}' | sort -u)
+
+    if [ -z "$images" ]; then
+        colorized_echo yellow "pasarguard/node images not found"
+        return 0
     fi
+
+    colorized_echo yellow "Checking pasarguard/node images for removal..."
+
+    for image in $images; do
+        if docker ps -a --filter "ancestor=$image" -q | grep -q .; then
+		    local container
+            container=$(docker ps -a --filter "ancestor=$image" --format '{{.Names}}' | tr '\n' ' ')
+            colorized_echo yellow "Skipping image $image (still used by: $container)"
+            continue
+        fi
+
+        if docker rmi "$image" >/dev/null 2>&1; then
+            colorized_echo yellow "Image $image removed"
+        else
+            colorized_echo yellow "Failed to remove image $image"
+        fi
+    done
 }
 uninstall_node_data_files() {
     if [ -d "$DATA_DIR" ]; then


### PR DESCRIPTION
This PR fixes `uninstall_node_docker_images()` and `uninstall_pasarguard_docker_images()` by removing brittle parsing of `docker images` output.
The previous implementation relied on `awk '{print $3}'`, which assumes a stable column layout and can extract the wrong field on newer Docker versions / different CLI formatting, causing `docker rmi` to fail silently.
The updated implementation uses `docker images --format` for stable extraction, filters only the intended repo (e.g. pasarguard/node), and skips removing images still used by any container.

Old docker:
<img width="565" height="75" alt="Screenshot 2025-12-31 094610" src="https://github.com/user-attachments/assets/6ef93d84-3265-4943-91cb-d4eafef73c0e" />

New docker:
<img width="640" height="94" alt="Screenshot 2025-12-31 094712" src="https://github.com/user-attachments/assets/e7a09b82-10cf-4609-9183-4ba4fa37da37" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker image removal safety: prevents removal of images currently in use by containers.
  * Enhanced error handling with better user messaging for missing images and removal failures.
  * Added pre-removal validation checks and per-image feedback during cleanup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->