### PR TITLE
feat(install): add port conflict detection before starting services

### DIFF
--- a/pasarguard.sh
+++ b/pasarguard.sh
@@ -3743,6 +3743,45 @@ install_command() {
         exit 1
     fi
     install_completion
+
+    # --- Port conflict detection ---
+    # Read the configured UVICORN_PORT from .env (default: 8000)
+    local configured_port
+    configured_port=$(grep -E '^\s*UVICORN_PORT\s*=' "$ENV_FILE" 2>/dev/null \
+        | head -1 | sed 's/^[^=]*=\s*//' | tr -d '[:space:]"' || true)
+    configured_port="${configured_port:-8000}"
+
+    if is_port_in_use "$configured_port"; then
+        colorized_echo yellow "Port ${configured_port} is already in use by another service."
+        colorized_echo yellow "PasarGuard will fail to start unless a free port is used."
+        echo
+
+        while true; do
+            read -p "Enter a different port for PasarGuard (1-65535) or 'q' to abort: " new_port
+            if [[ "$new_port" == "q" || "$new_port" == "Q" ]]; then
+                colorized_echo red "Installation aborted by user."
+                exit 1
+            fi
+            if ! [[ "$new_port" =~ ^[0-9]+$ ]] || [ "$new_port" -lt 1 ] || [ "$new_port" -gt 65535 ]; then
+                colorized_echo red "Invalid port number. Please enter a value between 1 and 65535."
+                continue
+            fi
+            if is_port_in_use "$new_port"; then
+                colorized_echo red "Port ${new_port} is also in use. Please choose another port."
+                continue
+            fi
+            break
+        done
+
+        set_or_uncomment_env_var "UVICORN_PORT" "$new_port" false "$ENV_FILE"
+        colorized_echo green "UVICORN_PORT updated to ${new_port} in ${ENV_FILE}"
+
+        # Update ALLOWED_ORIGINS to reflect the new port
+        if grep -qE '^\s*ALLOWED_ORIGINS\s*=' "$ENV_FILE"; then
+            sed -i "s|localhost:${configured_port}|localhost:${new_port}|g" "$ENV_FILE"
+        fi
+    fi
+
     up_pasarguard
 
     echo


### PR DESCRIPTION
## Summary

Adds automatic port conflict detection during installation to prevent the infinite Docker restart loop described in #10.

## Problem

When another service already occupies port 8000 (the default `UVICORN_PORT`), `docker compose up` starts PasarGuard with `network_mode: host`, which causes:

```
[Errno 98] error while attempting to bind on address ('0.0.0.0', 8000): address already in use
```

This leads to an **infinite restart loop** since there is no pre-flight port check.

## Solution

After the `.env` file is written and before `up_pasarguard()` starts the containers, the script now:

1. Reads the configured `UVICORN_PORT` from `.env` (defaults to 8000)
2. Checks if that port is already in use via the existing `is_port_in_use()` utility
3. If a conflict is detected, warns the user and prompts for an alternative port
4. Validates the new port (1-65535 range, not already in use)
5. Updates both `UVICORN_PORT` and `ALLOWED_ORIGINS` in `.env`

## Changes

- **pasarguard.sh**: Added ~39 lines of port conflict detection logic in `install_command()`, placed between `install_completion` and `up_pasarguard` calls.

## Testing

- Verified the detection logic uses the existing `is_port_in_use()` function (ss → netstat → lsof fallback chain)
- The prompt loop validates port range and re-checks availability before accepting

Closes #10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The installation process now intelligently detects if the configured port is already in use and interactively prompts you to select an available alternative. The system validates your port selection and automatically updates the configuration with the new port.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->