### PR TITLE
Fix: add crontab to acme.sh install dependency checks

### DIFF
--- a/pasarguard.sh
+++ b/pasarguard.sh
@@ -321,9 +321,25 @@ is_port_in_use() {
     return 1
 }
 
+get_cron_package_name() {
+    if [[ "$OS" == "Ubuntu"* ]] || [[ "$OS" == "Debian"* ]]; then
+        echo "cron"
+    elif [[ "$OS" == "CentOS"* ]] || [[ "$OS" == "AlmaLinux"* ]] || [ "$OS" == "Fedora"* ] || [ "$OS" == "Arch Linux" ]; then
+        echo "cronie"
+    else
+        return 1
+    fi
+}
+
 ensure_acme_dependencies() {
     command -v socat >/dev/null 2>&1 || install_package socat
     command -v openssl >/dev/null 2>&1 || install_package openssl
+
+    local cron_pkg
+    if ! command -v crontab >/dev/null 2>&1; then
+        cron_pkg="$(get_cron_package_name)"
+        install_package "$cron_pkg"
+    fi
 }
 
 install_acme() {

--- a/pasarguard.sh
+++ b/pasarguard.sh
@@ -345,8 +345,12 @@ ensure_acme_dependencies() {
 install_acme() {
     colorized_echo blue "Installing acme.sh for SSL certificate management..."
     if curl -s https://get.acme.sh | sh >/dev/null 2>&1; then
-        colorized_echo green "acme.sh installed successfully"
-        return 0
+        local acme_bin=""
+        acme_bin="$(get_acme_sh_binary)" || true
+        if [ -n "$acme_bin" ] && [ -x "$acme_bin" ]; then
+            colorized_echo green "acme.sh installed successfully"
+            return 0
+        fi
     fi
     colorized_echo red "Failed to install acme.sh"
     return 1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for automatic cron package installation across multiple Linux distributions, including Ubuntu, Debian, CentOS, AlmaLinux, Fedora, and Arch Linux
  * Enhanced ACME installation verification to ensure the binary is properly installed and executable before confirming successful installation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->