### PR TITLE
fix: correct sudo usage in node installer

### DIFF
--- a/pasarguard.sh
+++ b/pasarguard.sh
@@ -1783,11 +1783,11 @@ install_node_command() {
     echo
 
     if [ "$(id -u)" = "0" ]; then
+        colorized_echo blue "Running node installation as root..."
+        bash -c "$(curl -sL https://github.com/PasarGuard/scripts/raw/main/pg-node.sh)" @ install
+    else
         colorized_echo blue "Running node installation with sudo..."
         sudo bash -c "$(curl -sL https://github.com/PasarGuard/scripts/raw/main/pg-node.sh)" @ install
-    else
-        colorized_echo blue "Running node installation without sudo..."
-        bash -c "$(curl -sL https://github.com/PasarGuard/scripts/raw/main/pg-node.sh)" @ install
     fi
 
     if [ $? -eq 0 ]; then


### PR DESCRIPTION
## Summary

Fix root/non-root handling in `install_node_command()`.

### Problem

The current implementation invokes `sudo` when already running as root and runs the installer directly when not running as root:

```bash
if [ "$(id -u)" = "0" ]; then
    sudo bash -c "$(curl -sL https://github.com/PasarGuard/scripts/raw/main/pg-node.sh)" @ install
else
    bash -c "$(curl -sL https://github.com/PasarGuard/scripts/raw/main/pg-node.sh)" @ install
fi
```

This causes node installation to fail on systems where `sudo` is not installed.

### Reproduction

Environment:

* Debian 13
* Logged in as root
* `sudo` package not installed

Command:

```bash
pasarguard install-node
```

Output:

```text
Running node installation with sudo...
sudo: command not found
```

### Verification

After applying this patch:

```text
Running node installation as root...
Installing PasarGuard Node
...
```

The installer proceeds normally and reaches the next installation steps.

### Solution

* Run the node installer directly when already running as root.
* Use `sudo` only for non-root users.

Additionally, `pg-node.sh` already performs multiple `check_running_as_root` checks, so this change aligns the invocation logic with the installer requirements.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved node installation script execution to properly handle different user permission levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->