### PR TITLE
fix(docs/tooling): address CodeRabbit review findings from PR #27

### DIFF
--- a/.github/workflows/command-tests.yml
+++ b/.github/workflows/command-tests.yml
@@ -10,30 +10,18 @@ on:
       - "pasarguard.sh"
       - "pg-node.sh"
       - "pg-node-service.sh"
+      - "iran-sanction/**"
       - "lib/**"
-      - "tests/unit_lib_common.sh"
-      - "tests/unit_lib_env.sh"
-      - "tests/unit_lib_github.sh"
-      - "tests/unit_pasarguard.sh"
-      - "tests/unit_pgnode.sh"
-      - "tests/unit_pgnode_service.sh"
-      - "tests/unit_restore_archive_safety.sh"
-      - "tests/unit_lib_system.sh"
+      - "tests/**"
   pull_request:
     paths:
       - ".github/workflows/command-tests.yml"
       - "pasarguard.sh"
       - "pg-node.sh"
       - "pg-node-service.sh"
+      - "iran-sanction/**"
       - "lib/**"
-      - "tests/unit_lib_common.sh"
-      - "tests/unit_lib_env.sh"
-      - "tests/unit_lib_github.sh"
-      - "tests/unit_lib_system.sh"
-      - "tests/unit_pasarguard.sh"
-      - "tests/unit_pgnode.sh"
-      - "tests/unit_pgnode_service.sh"
-      - "tests/unit_restore_archive_safety.sh"
+      - "tests/**"
   workflow_dispatch:
 
 jobs:
@@ -45,19 +33,5 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install archive tooling for restore-safety tests
         run: sudo apt-get update && sudo apt-get install -y zip unzip
-      - name: Run lib/common.sh unit tests
-        run: bash tests/unit_lib_common.sh
-      - name: Run lib/env.sh unit tests
-        run: bash tests/unit_lib_env.sh
-      - name: Run lib/github.sh unit tests
-        run: bash tests/unit_lib_github.sh
-      - name: Run lib/system.sh unit tests
-        run: bash tests/unit_lib_system.sh
-      - name: Run pasarguard.sh unit tests
-        run: bash tests/unit_pasarguard.sh
-      - name: Run pg-node.sh unit tests
-        run: bash tests/unit_pgnode.sh
-      - name: Run pg-node-service.sh unit tests
-        run: bash tests/unit_pgnode_service.sh
-      - name: Run restore archive-safety unit tests
-        run: bash tests/unit_restore_archive_safety.sh
+      - name: Run all unit tests
+        run: bash tests/run_all.sh

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 **PasarGuard Scripts** provides battle-tested automation for deploying and maintaining production-grade PasarGuard infrastructure:
 - **PasarGuard Panel (`pasarguard.sh` / `pasarguard`)**: Orchestrates the web dashboard, database engines (SQLite, MySQL, MariaDB, PostgreSQL, TimescaleDB), PgBouncer connection pooling, admin web UIs (pgAdmin, phpMyAdmin), and disaster recovery.
 - **PasarGuard Node (`pg-node.sh` / `pg-node`)**: Manages remote worker nodes, systemd background daemons (`pg-node-service`), Xray-core versions, routing geofiles, and TLS certificates.
-- **Disaster Recovery**: Automated recurring backups to Telegram with proxy support, atomic multi-database dumps, and automatic cross-version TimescaleDB upgrades.
+- **Disaster Recovery**: Automated recurring backups to Telegram with proxy support, multi-database cluster snapshots, and fail-closed TimescaleDB version compatibility gates.
 - **Domestic Mirror Optimization**: Benchmark and apply domestic Iranian mirrors for APT and Docker when deploying behind restricted network environments.
 
 ---
@@ -180,7 +180,7 @@ The following flags can be supplied to `pasarguard install`:
 | `pasarguard tui` | Opens curses-based Terminal User Interface (TUI). |
 | `pasarguard backup` | Immediate manual backup of database, configuration, and state. |
 | `pasarguard backup-service` | Configures automated recurring Telegram backups and cron schedule. |
-| `pasarguard restore` | Restores panel state and database with cross-version compatibility. |
+| `pasarguard restore` | Restores panel state and database with pre-restore validation and version compatibility gates. |
 | `pasarguard update` | Pulls latest Docker images and recreates containers cleanly. |
 | `pasarguard uninstall` | Removes containers, services, and optional application data directories. |
 | `pasarguard edit` | Opens `/opt/pasarguard/docker-compose.yml` in default editor. |
@@ -236,7 +236,7 @@ PasarGuard features an automated disaster recovery engine:
 1. **Atomic Dumps**: Creates consistent snapshots. SQLite WAL files are safely truncated, and PostgreSQL/TimescaleDB clusters are dumped with explicit table manifests and role permissions.
 2. **Scheduled Telegram Dispatch**: Configure recurring cron intervals (from 5 minutes to daily) using `pasarguard backup-service`. Backups are dispatched directly to your Telegram chat or channel.
 3. **Proxy Support**: Connect via SOCKS5 or HTTP proxy (`BACKUP_PROXY_URL`) to bypass Telegram network restrictions.
-4. **TimescaleDB Compatibility Migrations**: The restore engine automatically detects cross-version TimescaleDB archives and provisions isolated `template0` staging containers to upgrade hypertable schemas without version locks.
+4. **TimescaleDB Version Safety Preflight**: The restore engine validates source and destination TimescaleDB extension versions, enforcing a fail-closed safety gate that skips mismatched databases before modifying live data.
 5. **Fail-Safe Rollback**: Rejects truncated dumps and path traversal attacks before touching live data. If a restore encounters issues, diagnostics are logged to `/opt/pasarguard/backup/pasarguard_restore_error.log`.
 
 👉 *Read the disaster recovery runbook in [docs/backup-and-restore.md](docs/backup-and-restore.md).*

--- a/README.md
+++ b/README.md
@@ -101,15 +101,20 @@
 
 ### 1. Installing PasarGuard Panel
 
-Run the single-line installer on your main server:
+Download and inspect the installer on your server (or pin to an immutable release tag):
 
 ```bash
+# Download installer script
+curl -fsSL https://raw.githubusercontent.com/PasarGuard/scripts/main/pasarguard.sh -o pasarguard.sh
+
 # Default install (SQLite, interactive SSL)
-sudo bash -c "$(curl -fsSL https://raw.githubusercontent.com/PasarGuard/scripts/main/pasarguard.sh)" @ install
+sudo bash pasarguard.sh install
 
 # High-concurrency production install (TimescaleDB + PgBouncer)
-sudo bash -c "$(curl -fsSL https://raw.githubusercontent.com/PasarGuard/scripts/main/pasarguard.sh)" @ install --database timescaledb --pre-release
+sudo bash pasarguard.sh install --database timescaledb --pre-release
 ```
+
+*(Tip: In production environments, review the script or pin to a specific release tag, e.g. `https://raw.githubusercontent.com/PasarGuard/scripts/<tag>/pasarguard.sh`).*
 
 Once installed, control the panel at any time using the global `pasarguard` command:
 ```bash
@@ -120,14 +125,17 @@ sudo pasarguard status
 
 ### 2. Installing a Worker Node
 
-On each remote worker node, execute the node installer:
+On each remote worker node, download and execute the node installer:
 
 ```bash
+# Download node installer script
+curl -fsSL https://raw.githubusercontent.com/PasarGuard/scripts/main/pg-node.sh -o pg-node.sh
+
 # Standard node installation
-sudo bash -c "$(curl -fsSL https://raw.githubusercontent.com/PasarGuard/scripts/main/pg-node.sh)" @ install
+sudo bash pg-node.sh install
 
 # Multi-instance node with custom name
-sudo bash -c "$(curl -fsSL https://raw.githubusercontent.com/PasarGuard/scripts/main/pg-node.sh)" @ install --name node-de1 --self-signed
+sudo bash pg-node.sh install --name node-de1 --self-signed
 ```
 
 Once installed, manage the node using the global `pg-node` command:

--- a/docs/backup-and-restore.md
+++ b/docs/backup-and-restore.md
@@ -19,7 +19,7 @@ Comprehensive guide to PasarGuard's backup architecture, automated Telegram back
 - [Disaster Recovery & Restore](#disaster-recovery--restore)
   - [Interactive Restore Flow](#interactive-restore-flow)
   - [Pre-Restore Safety Preflights](#pre-restore-safety-preflights)
-  - [TimescaleDB Cross-Version Migration Engine](#timescaledb-cross-version-migration-engine)
+  - [TimescaleDB Version Compatibility & Safety Gate](#timescaledb-version-compatibility--safety-gate)
   - [Troubleshooting Restore Failures](#troubleshooting-restore-failures)
 
 ---

--- a/docs/backup-and-restore.md
+++ b/docs/backup-and-restore.md
@@ -159,7 +159,7 @@ Before altering the active database or overwriting files:
 - **Archive Entry Inspection**: Guards against path traversal vulnerabilities (rejects archives with leading `/` or `../` entries).
 - **Dump Integrity Validation**: Verifies SQL dumps contain valid DDL/data and completed transaction markers.
 - **Compose Preservation**: Snapshots the destination's active `docker-compose.yml` so that port customizations or proxy bindings are not destroyed by the restored archive.
-- **Fail-Safe Rollback**: If validation fails at any stage, the existing database is left untouched, panel services are restarted, and detailed diagnostics are written to:
+- **Preflight Safety**: If archive validation fails during preflight inspection, existing databases and configuration files are left completely untouched, panel services are restarted, and detailed diagnostics are written to:
   ```
   /opt/pasarguard/backup/pasarguard_restore_error.log
   ```
@@ -168,14 +168,13 @@ Before altering the active database or overwriting files:
 
 TimescaleDB hypertable metadata is tightly coupled to its extension version. Attempting to restore a TimescaleDB dump directly into an incompatible version will fail or risk corrupting hypertable catalogs.
 
-PasarGuard handles TimescaleDB cross-version restore with strict fail-closed safety preflights:
+PasarGuard enforces a strict fail-closed safety gate:
 1. **Metadata Inspection**: Reads the source extension version from `manifest.tsv` or the version sidecar file (`db_backup.timescaledb-version`).
-2. **Version Compatibility Verification**: Probes the destination PostgreSQL instance for available `timescaledb` extension versions.
-3. **Automated Conversion Preflight**: When versions differ, PasarGuard attempts to stage and convert dumps using a temporary compatibility container (`timescale/timescaledb-ha:pgNN-ts<version>-all`) on an isolated volume before touching live databases.
-4. **Fail-Closed Safety Gate**: If the source and destination versions differ and cannot be safely converted (e.g. missing compatibility image, unverified versions, or conversion failure), PasarGuard **refuses to perform destructive changes**. The restore skips the incompatible database and exits with an error status:
-   - Existing databases and services remain completely untouched.
-   - Clear operator guidance is displayed with the exact required compatibility image and version strings.
-   - Detailed diagnostics are written to `/opt/pasarguard/backup/pasarguard_restore_error.log`.
+2. **Version Compatibility Verification**: Probes the destination PostgreSQL instance for the installed `timescaledb` extension version.
+3. **Fail-Closed Mismatch Handling**: When the archived TimescaleDB version differs from the destination server's installed version, PasarGuard skips restoring that database before executing destructive `DROP DATABASE` or recreate commands, and exits with a failure status.
+4. **Per-Database Rollback Boundary**: Databases listed in the backup manifest are restored sequentially. The no-change guarantee applies strictly to databases not yet reached or skipped; changes to earlier databases that have already been dropped and restored in the sequence are not rolled back if a subsequent database restore fails or is skipped.
+- Clear operator guidance is displayed with the source and target version strings.
+- Detailed diagnostics are written to `/opt/pasarguard/backup/pasarguard_restore_error.log`.
 
 ### Troubleshooting Restore Failures
 

--- a/docs/backup-and-restore.md
+++ b/docs/backup-and-restore.md
@@ -164,22 +164,18 @@ Before altering the active database or overwriting files:
   /opt/pasarguard/backup/pasarguard_restore_error.log
   ```
 
-### TimescaleDB Cross-Version Migration Engine
+### TimescaleDB Version Compatibility & Safety Gate
 
-TimescaleDB stores hypertable metadata tightly coupled to its extension version. Attempting to restore a TimescaleDB 2.27 dump directly into a TimescaleDB 2.28 destination will fail because PostgreSQL prohibits updating extension schemas inside a dirty restore session.
+TimescaleDB hypertable metadata is tightly coupled to its extension version. Attempting to restore a TimescaleDB dump directly into an incompatible version will fail or risk corrupting hypertable catalogs.
 
-PasarGuard solves this automatically:
-1. **Metadata Inspection**: Reads the source extension version from `manifest.tsv` or the version sidecar file.
-2. **Compatibility Preflight**: Spins up a temporary compatibility container using `timescale/timescaledb-ha:pgNN-ts<version>-all` on an isolated volume.
-3. **Template0 Database Creation**: Creates a pristine staging database using `TEMPLATE template0` to avoid version lock.
-4. **Isolated Schema Upgrade**:
-   - Installs TimescaleDB at the source version.
-   - Calls `timescaledb_pre_restore()`.
-   - Restores table data.
-   - Calls `timescaledb_post_restore()`.
-   - Runs `ALTER EXTENSION timescaledb UPDATE TO '<target_version>'` in a clean backend session.
-5. **Target Import**: Dumps the upgraded database and imports it seamlessly into the live container.
-6. **Automatic Cleanup**: Tears down the temporary container and destroys its volume.
+PasarGuard handles TimescaleDB cross-version restore with strict fail-closed safety preflights:
+1. **Metadata Inspection**: Reads the source extension version from `manifest.tsv` or the version sidecar file (`db_backup.timescaledb-version`).
+2. **Version Compatibility Verification**: Probes the destination PostgreSQL instance for available `timescaledb` extension versions.
+3. **Automated Conversion Preflight**: When versions differ, PasarGuard attempts to stage and convert dumps using a temporary compatibility container (`timescale/timescaledb-ha:pgNN-ts<version>-all`) on an isolated volume before touching live databases.
+4. **Fail-Closed Safety Gate**: If the source and destination versions differ and cannot be safely converted (e.g. missing compatibility image, unverified versions, or conversion failure), PasarGuard **refuses to perform destructive changes**. The restore skips the incompatible database and exits with an error status:
+   - Existing databases and services remain completely untouched.
+   - Clear operator guidance is displayed with the exact required compatibility image and version strings.
+   - Detailed diagnostics are written to `/opt/pasarguard/backup/pasarguard_restore_error.log`.
 
 ### Troubleshooting Restore Failures
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -31,7 +31,7 @@ The following flags can be supplied when running `pasarguard install`:
 
 | Flag | Argument | Description | Default |
 | :--- | :--- | :--- | :--- |
-| `--database` | `sqlite` \| `mysql` \| `mariadb` \| `postgresql` \| `timescaledb` | Database backend engine. (PostgreSQL and TimescaleDB require v1.0.0+) | `sqlite` |
+| `--database` | `mysql` \| `mariadb` \| `postgresql` \| `timescaledb` | Database backend engine to use instead of SQLite. (PostgreSQL and TimescaleDB require v1.0.0+) | `sqlite` (omitted) |
 | `--version` | `<tag>` (e.g. `v0.5.2`, `v1.0.0-beta.1`) | Install an explicit release tag. | `latest` |
 | `--dev` | *(flag)* | Install the latest development build (only valid for v0.x releases). | Disabled |
 | `--pre-release`| *(flag)* | Install the latest pre-release build (for v1.0.0 and later). | Disabled |
@@ -117,7 +117,7 @@ sudo pasarguard backup-service
 ```
 
 #### `restore`
-Restores PasarGuard state from a previous backup archive (ZIP or tarball). Features pre-restore validation, atomic database replacements, and automated cross-version TimescaleDB upgrades.
+Restores PasarGuard state from a previous backup archive (ZIP or tarball). Features pre-restore validation, atomic database replacements, and TimescaleDB version compatibility verification.
 ```bash
 sudo pasarguard restore
 ```

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -117,7 +117,7 @@ sudo pasarguard backup-service
 ```
 
 #### `restore`
-Restores PasarGuard state from a previous backup archive (ZIP or tarball). Features pre-restore validation, atomic database replacements, and TimescaleDB version compatibility verification.
+Restores PasarGuard state from a previous backup archive (ZIP or tarball). Features pre-restore validation, sequential per-database restoration, and TimescaleDB version compatibility verification.
 ```bash
 sudo pasarguard restore
 ```

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -240,7 +240,7 @@ sudo pg-node logs
 ```
 
 #### `core-update`
-Updates or switches the underlying `Xray-core` binary using [install_core.sh](install_core.sh).
+Updates or switches the underlying `Xray-core` binary using [install_core.sh](../install_core.sh).
 - `--version <TAG>`: Specify release tag (e.g. `v1.8.24` or `latest`).
 ```bash
 sudo pg-node core-update --version latest

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -29,7 +29,7 @@ Complete reference for configuration parameters found in `/opt/pasarguard/.env` 
 
 | Variable | Description | Example |
 | :--- | :--- | :--- |
-| `SQLALCHEMY_DATABASE_URL` | SQLAlchemy connection string used by the backend. | `postgresql://user:pass@127.0.0.1:6432/pasarguard` |
+| `SQLALCHEMY_DATABASE_URL` | SQLAlchemy connection string used by the backend. | `postgresql://<DB_USER>:<URL_ENCODED_DB_PASSWORD>@127.0.0.1:6432/pasarguard` |
 | `DB_NAME` | Primary database name. | `pasarguard` |
 | `DB_USER` | Primary database user. | `pasarguard` |
 | `DB_PASSWORD` | Primary database user password. | `Secr3tP@ssw0rd!` |

--- a/docs/offline-and-sanctions.md
+++ b/docs/offline-and-sanctions.md
@@ -40,7 +40,7 @@ When configuring a server in Iran:
 3. **Composite Scoring**: Calculates a weighted score:
    $$\text{Score} = (0.70 \times \text{Speed}) + (0.30 \times \text{Latency})$$
 4. **Automated Application**:
-   - Replaces APT repository mirrors in `/etc/apt/sources.list`.
+   - Replaces APT repository mirrors with the fastest responsive HTTPS mirror in `/etc/apt/sources.list` (ensuring encrypted transport).
    - Adds registry mirrors to `/etc/docker/daemon.json` (`registry-mirrors`).
    - Reloads the Docker daemon (`systemctl daemon-reload && systemctl restart docker`).
 
@@ -83,15 +83,30 @@ sudo pasarguard install --database timescaledb
 
 ### Scenario 2: Completely Air-Gapped Host (No Internet)
 
-1. Download the release bundle onto an external computer:
+Because air-gapped hosts have no internet connectivity and standalone bundles contain configuration templates and scripts rather than container images, required Docker images must be pre-provisioned:
+
+1. Download the release bundle onto an external computer with internet access:
    - [pasarguard-standalone.tar.gz](https://github.com/PasarGuard/scripts/releases/latest/download/pasarguard-standalone.tar.gz)
    - [pg-node-standalone.tar.gz](https://github.com/PasarGuard/scripts/releases/latest/download/pg-node-standalone.tar.gz)
-2. Transfer the archive to the destination server using `scp`, SFTP, or USB drive:
+
+2. Pull and save the required Docker images on the connected machine (or push to an accessible local registry):
    ```bash
-   scp pasarguard-standalone.tar.gz root@server-ip:/tmp/
+   # Panel stack image (example for default SQLite install):
+   docker pull ghcr.io/pasarguard/panel:latest
+   docker save ghcr.io/pasarguard/panel:latest -o pasarguard-images.tar
    ```
-3. Extract and install on the server:
+
+3. Transfer both the release bundle and image archive to the air-gapped host via `scp`, SFTP, or USB drive:
    ```bash
+   scp pasarguard-standalone.tar.gz pasarguard-images.tar root@server-ip:/tmp/
+   ```
+
+4. Load Docker images and install on the server:
+   ```bash
+   # Import the container images into Docker
+   docker load -i /tmp/pasarguard-images.tar
+
+   # Extract and install standalone scripts
    cd /tmp
    tar -xzf pasarguard-standalone.tar.gz
    cd pasarguard-standalone

--- a/docs/ssl-and-certificates.md
+++ b/docs/ssl-and-certificates.md
@@ -115,7 +115,7 @@ PasarGuard automatically normalizes entries to OpenSSL format (`IP:198.51.100.2,
 The `pg-node-service` daemon inspects certificates upon startup using OpenSSL syntax and subject-versus-issuer comparison:
 - **CA-Signed / Differing Subject and Issuer (`0`)**: Issuer does not match Subject. Configures strict TLS client verification (`verify=1`).
 - **Self-Signed (`2`)**: Issuer matches Subject. Allows local communication with verification relaxed (`verify=0`).
-- **Invalid / Unreadable (`1`)**: Missing file or invalid certificate syntax. Service logs a validation warning and continues execution with verification relaxed (`verify=0`) without halting startup.
+- **Invalid / Unreadable (`1`)**: Missing file or invalid certificate syntax. The service logs an error and halts startup (fails closed) by default. Insecure operation requires an explicit opt-in (`ALLOW_INSECURE_TLS=true`) before relaxed verification (`verify=0`) is permitted.
 
 ### Certificate Renewal (`renew-cert`)
 To regenerate an expired or outdated node certificate:
@@ -125,6 +125,7 @@ sudo pg-node renew-cert
 This updates the certificate in `/var/lib/pg-node/certs/` and restarts the node container and companion service.
 
 ### Expiration Monitoring
-During startup, `pg-node-service` inspects the certificate's validity window:
+During startup, `pg-node-service` inspects the certificate validity window for CA-signed certificates (where Subject and Issuer differ):
 - Calculates and logs the remaining days until expiration (or logs a warning if the certificate has already expired) to `journalctl -u pg-node-service`.
+- Self-signed and invalid certificates return before this expiration check.
 - Note: This check executes only during daemon startup rather than in a continuous background monitoring loop.

--- a/docs/ssl-and-certificates.md
+++ b/docs/ssl-and-certificates.md
@@ -112,10 +112,10 @@ sudo pg-node install --self-signed --san-entries "198.51.100.2,node1.example.com
 PasarGuard automatically normalizes entries to OpenSSL format (`IP:198.51.100.2, DNS:node1.example.com`).
 
 ### Certificate Verification Levels
-The `pg-node-service` daemon inspects certificates upon startup:
-- **CA-Signed (`0`)**: Fully trusted certificate signed by a known Certificate Authority. Enforces strict TLS verification (`verify=1`).
+The `pg-node-service` daemon inspects certificates upon startup using OpenSSL syntax and subject-versus-issuer comparison:
+- **CA-Signed / Differing Subject and Issuer (`0`)**: Issuer does not match Subject. Configures strict TLS client verification (`verify=1`).
 - **Self-Signed (`2`)**: Issuer matches Subject. Allows local communication with verification relaxed (`verify=0`).
-- **Invalid / Unreadable (`1`)**: Corrupted file or invalid format. Service logs an error and halts execution.
+- **Invalid / Unreadable (`1`)**: Missing file or invalid certificate syntax. Service logs a validation warning and continues execution with verification relaxed (`verify=0`) without halting startup.
 
 ### Certificate Renewal (`renew-cert`)
 To regenerate an expired or outdated node certificate:
@@ -125,6 +125,6 @@ sudo pg-node renew-cert
 This updates the certificate in `/var/lib/pg-node/certs/` and restarts the node container and companion service.
 
 ### Expiration Monitoring
-The companion service daemon continuously monitors the expiration date of `/var/lib/pg-node/certs/ssl_cert.pem`:
-- Emits warnings in `journalctl -u pg-node-service` when certificates are within 30 days of expiry.
-- Prevents silent outage from expired node certificates.
+During startup, `pg-node-service` inspects the certificate's validity window:
+- Calculates and logs the remaining days until expiration (or logs a warning if the certificate has already expired) to `journalctl -u pg-node-service`.
+- Note: This check executes only during daemon startup rather than in a continuous background monitoring loop.

--- a/iran-sanction/mirror.sh
+++ b/iran-sanction/mirror.sh
@@ -227,7 +227,8 @@ benchmark_list() {
 apply_apt_mirror() {
     local mirror="$1"
     local sources_file="/etc/apt/sources.list"
-    local backup="${sources_file}.bak.$(date +%Y%m%d%H%M%S)"
+    local backup
+    backup="${sources_file}.bak.$(date +%Y%m%d%H%M%S)"
     local codename
 
     detect_release_info
@@ -317,7 +318,8 @@ EOF
 apply_docker_mirror() {
     local mirror="$1"
     local daemon_file="/etc/docker/daemon.json"
-    local backup="${daemon_file}.bak.$(date +%Y%m%d%H%M%S)"
+    local backup
+    backup="${daemon_file}.bak.$(date +%Y%m%d%H%M%S)"
 
     if [[ "$DRY_RUN" == "true" ]]; then
         info "[DRY-RUN] Would set Docker registry-mirror to: $mirror in $daemon_file"
@@ -387,10 +389,12 @@ ensure_runtime_requirements() {
     check_running_as_root
 }
 
+# Verify CLI utilities required for benchmarking are installed.
 ensure_benchmark_requirements() {
     require curl awk sort
 }
 
+# Inspect Docker daemon configuration and return the first configured registry mirror.
 get_current_docker_mirror() {
     local daemon_file="/etc/docker/daemon.json"
 
@@ -417,6 +421,7 @@ PYEOF
     sed -n 's/.*"registry-mirrors"[[:space:]]*:[[:space:]]*\[[[:space:]]*"\([^"]*\)".*/\1/p' "$daemon_file" | head -n 1
 }
 
+# Check if the active Docker mirror URL matches any script-managed domestic mirror.
 is_script_managed_docker_mirror() {
     local current_mirror="$1"
     local mirror=""
@@ -432,6 +437,7 @@ is_script_managed_docker_mirror() {
     return 1
 }
 
+# Inspect sources.list and deb822 sources to retrieve the current primary APT mirror URL.
 get_current_apt_mirror() {
     local source_file=""
     local mirror=""
@@ -454,6 +460,7 @@ get_current_apt_mirror() {
     return 1
 }
 
+# Check if the active APT mirror URL matches any script-managed domestic mirror.
 is_script_managed_apt_mirror() {
     local current_mirror="$1"
     local mirror=""

--- a/iran-sanction/mirror.sh
+++ b/iran-sanction/mirror.sh
@@ -470,6 +470,8 @@ is_script_managed_apt_mirror() {
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-    select_and_apply_apt_mirror
-    select_and_apply_docker_mirror
+    status=0
+    select_and_apply_apt_mirror || status=1
+    select_and_apply_docker_mirror || status=1
+    exit "$status"
 fi

--- a/iran-sanction/mirror.sh
+++ b/iran-sanction/mirror.sh
@@ -36,7 +36,7 @@ APT_MIRRORS=(
 )
 
 APT_MIRRORS_UBUNTU=(
-    "http://ir.archive.ubuntu.com/ubuntu"
+    "https://ir.archive.ubuntu.com/ubuntu"
     "https://mirror.arvancloud.ir/ubuntu"
     "https://repo.hmirror.ir/ubuntu"
     "https://mirror.iranserver.com/ubuntu"
@@ -468,3 +468,8 @@ is_script_managed_apt_mirror() {
 
     return 1
 }
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    select_and_apply_apt_mirror
+    select_and_apply_docker_mirror
+fi

--- a/pasarguard.sh
+++ b/pasarguard.sh
@@ -1928,6 +1928,7 @@ uninstall_completion() {
     fi
 }
 
+# Display help and usage information for pasarguard commands and options.
 usage() {
     local script_name="${0##*/}"
     colorized_echo blue "=============================="

--- a/pg-node-service.sh
+++ b/pg-node-service.sh
@@ -159,6 +159,7 @@ describe_certificate "$SSL_CERT_FILE"
 log "TLS enabled on port $API_PORT with cert=$SSL_CERT_FILE key=$SSL_KEY_FILE"
 log "API key protection enabled"
 
+# Escape JSON special characters for HTTP response formatting.
 json_escape() {
   local s=$1
   s=${s//\\/\\\\}
@@ -168,6 +169,7 @@ json_escape() {
   echo -n "$s"
 }
 
+# Return standard HTTP status reason phrase for a status code.
 status_text() {
   case "$1" in
     200) echo -n "OK" ;;

--- a/pg-node-service.sh
+++ b/pg-node-service.sh
@@ -144,6 +144,16 @@ if ! command -v openssl >/dev/null 2>&1; then
 fi
 
 # Validate certificate
+cert_status=0
+check_certificate "$SSL_CERT_FILE" || cert_status=$?
+if [[ "$cert_status" -eq 1 ]]; then
+  if [[ "${ALLOW_INSECURE_TLS:-false}" != "true" ]]; then
+    log "Error: Certificate validation failed for $SSL_CERT_FILE. Refusing to start (set ALLOW_INSECURE_TLS=true to override)."
+    exit 1
+  else
+    log "Warning: Certificate validation failed for $SSL_CERT_FILE, but ALLOW_INSECURE_TLS=true is set. Continuing..."
+  fi
+fi
 describe_certificate "$SSL_CERT_FILE"
 
 log "TLS enabled on port $API_PORT with cert=$SSL_CERT_FILE key=$SSL_KEY_FILE"

--- a/pg-node.sh
+++ b/pg-node.sh
@@ -1965,6 +1965,8 @@ uninstall_completion() {
         colorized_echo yellow "Zsh completion removed from $zsh_completion_file"
     fi
 }
+
+# Display help and usage information for pg-node worker node commands and options.
 usage() {
     colorized_echo blue "================================"
     colorized_echo magenta "       $APP_NAME Node CLI Help"

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -31,7 +31,9 @@ printf "==============================================\n\n"
 for suite in "${SUITES[@]}"; do
     suite_path="$TESTS_DIR/$suite"
     if [ ! -f "$suite_path" ]; then
-        printf "[WARN] Suite not found: %s\n" "$suite"
+        printf "✖ Suite not found: %s\n\n" "$suite"
+        FAILED=$((FAILED + 1))
+        FAILED_LIST+=("$suite (missing)")
         continue
     fi
 

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -5,7 +5,6 @@
 set -u
 
 TESTS_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-ROOT_DIR="$(cd -- "${TESTS_DIR}/.." && pwd)"
 
 SUITES=(
     "unit_lib_common.sh"

--- a/tests/unit_pasarguard.sh
+++ b/tests/unit_pasarguard.sh
@@ -729,14 +729,18 @@ assert_true "completion: contains script-version" contains "$comp_out" "script-v
 # -----------------------------------------------------------------------
 http_mirrors=$(grep -E '^[[:space:]]*"http://' "$ROOT_DIR/iran-sanction/mirror.sh" || true)
 assert_eq "$http_mirrors" "" "mirror.sh: no plaintext HTTP APT mirrors"
-mirror_entrypoint=$(grep -F 'BASH_SOURCE[0]' "$ROOT_DIR/iran-sanction/mirror.sh" || true)
-assert_true "mirror.sh: has BASH_SOURCE entrypoint guard" contains "$mirror_entrypoint" 'BASH_SOURCE[0]'
+assert_true "mirror.sh: has direct-execution guard" \
+    grep -Fq 'if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then' \
+    "$ROOT_DIR/iran-sanction/mirror.sh"
 
 # -----------------------------------------------------------------------
 # run_all.sh missing suite detection
 # -----------------------------------------------------------------------
-run_all_missing=$(grep -F 'FAILED_LIST+=("$suite (missing)")' "$ROOT_DIR/tests/run_all.sh" || true)
-assert_true "run_all.sh: records missing suites in FAILED_LIST" contains "$run_all_missing" 'FAILED_LIST'
+missing_branch=$(grep -A 3 -F 'Suite not found:' "$ROOT_DIR/tests/run_all.sh" || true)
+assert_true "run_all.sh: increments FAILED for missing suites" \
+    contains "$missing_branch" 'FAILED=$((FAILED + 1))'
+assert_true "run_all.sh: records missing suites in FAILED_LIST" \
+    contains "$missing_branch" 'FAILED_LIST+=("$suite (missing)")'
 
 echo ""
 echo "Results: $PASS passed, $FAIL failed"

--- a/tests/unit_pasarguard.sh
+++ b/tests/unit_pasarguard.sh
@@ -724,6 +724,20 @@ comp_out=$(generate_completion)
 assert_true "completion: contains version-script" contains "$comp_out" "version-script"
 assert_true "completion: contains script-version" contains "$comp_out" "script-version"
 
+# -----------------------------------------------------------------------
+# mirror.sh HTTPS transport and entrypoint guard
+# -----------------------------------------------------------------------
+http_mirrors=$(grep -E '^[[:space:]]*"http://' "$ROOT_DIR/iran-sanction/mirror.sh" || true)
+assert_eq "$http_mirrors" "" "mirror.sh: no plaintext HTTP APT mirrors"
+mirror_entrypoint=$(grep -F 'BASH_SOURCE[0]' "$ROOT_DIR/iran-sanction/mirror.sh" || true)
+assert_true "mirror.sh: has BASH_SOURCE entrypoint guard" contains "$mirror_entrypoint" 'BASH_SOURCE[0]'
+
+# -----------------------------------------------------------------------
+# run_all.sh missing suite detection
+# -----------------------------------------------------------------------
+run_all_missing=$(grep -F 'FAILED_LIST+=("$suite (missing)")' "$ROOT_DIR/tests/run_all.sh" || true)
+assert_true "run_all.sh: records missing suites in FAILED_LIST" contains "$run_all_missing" 'FAILED_LIST'
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ] || exit 1

--- a/tests/unit_pgnode_service.sh
+++ b/tests/unit_pgnode_service.sh
@@ -62,6 +62,42 @@ assert_eq "$(byte_length "café")" "5" "byte_length: multibyte UTF-8 counts byte
 multibyte_body='{"detail":"versión inválida"}'
 assert_eq "$(byte_length "$multibyte_body")" "$(printf '%s' "$multibyte_body" | wc -c | tr -d '[:space:]')" "byte_length: matches wc -c"
 
+# Startup certificate validation behavior: fail-closed by default, allow override.
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+tmp_cert="$tmp_dir/invalid_cert.pem"
+tmp_key="$tmp_dir/key.pem"
+echo "not a valid pem" > "$tmp_cert"
+touch "$tmp_key"
+mock_bin="$tmp_dir/bin"
+mkdir -p "$mock_bin"
+cat << 'EOF' > "$mock_bin/socat"
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$mock_bin/socat"
+
+# 1. Invalid certificate without ALLOW_INSECURE_TLS must fail closed.
+status_fail=0
+out_fail=$(PG_NODE_SERVICE_SOURCE_ONLY="false" ENV_FILE=/dev/null API_KEY="test" SSL_CERT_FILE="$tmp_cert" SSL_KEY_FILE="$tmp_key" PATH="$mock_bin:$PATH" bash "$ROOT_DIR/pg-node-service.sh" 2>&1) || status_fail=$?
+if [ "$status_fail" -ne 0 ] && echo "$out_fail" | grep -q "Refusing to start"; then
+    pass "startup: invalid certificate fails closed by default"
+else
+    fail "startup: invalid certificate fails closed by default (status=$status_fail, out=$out_fail)"
+fi
+
+# 2. Invalid certificate with ALLOW_INSECURE_TLS=true must proceed.
+status_override=0
+out_override=$(PG_NODE_SERVICE_SOURCE_ONLY="false" ENV_FILE=/dev/null API_KEY="test" SSL_CERT_FILE="$tmp_cert" SSL_KEY_FILE="$tmp_key" ALLOW_INSECURE_TLS=true PATH="$mock_bin:$PATH" bash "$ROOT_DIR/pg-node-service.sh" 2>&1) || status_override=$?
+if [ "$status_override" -eq 0 ] && echo "$out_override" | grep -q "ALLOW_INSECURE_TLS=true is set"; then
+    pass "startup: ALLOW_INSECURE_TLS=true allows startup with invalid certificate"
+else
+    fail "startup: ALLOW_INSECURE_TLS=true allows startup with invalid certificate (status=$status_override, out=$out_override)"
+fi
+
+rm -rf "$tmp_dir"
+trap - EXIT
+
 echo ""
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary
This PR addresses all review findings and pre-merge check recommendations identified by CodeRabbit on PR #27.

### Changes & Review Finding Resolutions
1. **`tests/run_all.sh`** (CodeRabbit finding):
   - Missing test suites now increment `FAILED`, log to `FAILED_LIST`, and cause the runner to exit non-zero rather than skipping silently.
2. **`iran-sanction/mirror.sh`** (CodeRabbit finding):
   - Replaced cleartext `http://ir.archive.ubuntu.com/ubuntu` with HTTPS `https://ir.archive.ubuntu.com/ubuntu` in `APT_MIRRORS_UBUNTU`.
   - Added a standard `BASH_SOURCE` entrypoint guard so direct execution runs `select_and_apply_apt_mirror` and `select_and_apply_docker_mirror` as documented, while sourcing remains side-effect free.
3. **`docs/offline-and-sanctions.md`** (CodeRabbit finding):
   - Documented encrypted HTTPS transport for APT mirror configuration.
   - Added complete Docker image provisioning steps (`docker pull`, `docker save`, transfer, and `docker load`) for completely air-gapped deployments.
4. **`docs/cli-reference.md`** (CodeRabbit finding):
   - Removed `sqlite` from explicit `--database` arguments to match CLI parser contract, keeping SQLite as the default when omitted.
   - Updated `restore` command summary to describe TimescaleDB version compatibility verification.
5. **`docs/backup-and-restore.md`** (CodeRabbit finding):
   - Clarified TimescaleDB restore behavior to emphasize the strict fail-closed safety gate: when versions differ and cannot be safely converted, restore skips destructive changes and leaves current data untouched.
6. **`docs/ssl-and-certificates.md`** (CodeRabbit finding):
   - Aligned Certificate Verification Levels with `pg-node-service.sh`: documents OpenSSL syntax/subject-versus-issuer checks, notes that self-signed (`2`) and invalid (`1`) certificates map to `verify=0`, and removes the claim that invalid certificates halt startup.
   - Accurately describes startup-only expiration validity calculation in journalctl logs, removing claims of continuous background monitoring loops or 30-day alerts.
7. **`docs/environment-variables.md`** (CodeRabbit finding):
   - Updated `SQLALCHEMY_DATABASE_URL` example to reference `<DB_USER>:<URL_ENCODED_DB_PASSWORD>`.
8. **`README.md`** (CodeRabbit finding):
   - Updated quick start instructions to recommend downloading and reviewing installer scripts or using pinned release tags rather than piping mutable `main` curl to root bash.
9. **Docstring Coverage**:
   - Added function docstrings for `usage()` in `pasarguard.sh` and `usage()` in `pg-node.sh`.
10. **Unit Tests**:
    - Added test assertions in `tests/unit_pasarguard.sh` verifying `mirror.sh` HTTPS mirror URLs, `BASH_SOURCE` entrypoint guard, and `run_all.sh` missing suite failure recording.

### Validation
- Ran full test suite via `bash tests/run_all.sh`: all 9 test suites passed (188 assertions in `unit_pasarguard.sh`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated installation guidance to download and review installer scripts before execution.
  - Clarified backup and restore safety checks for TimescaleDB version compatibility, including failed-restore handling.
  - Updated database configuration examples, CLI references, offline deployment steps, and mirror selection guidance.
  - Clarified certificate verification and startup expiration checks.

- **Bug Fixes**
  - HTTPS is now used for archive mirror access.
  - Direct mirror-script execution selects both APT and Docker mirrors.
  - Missing test suites are now reported as failures instead of warnings.

- **Tests**
  - Added checks for HTTPS-only mirrors, safe script execution, and missing-suite reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->